### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "ES6",
         "SCSS"
     ],
-    "author": "Jérémy Levron <jeremylevron@19h47.fr> (http://19h47.fr)",
+    "author": "JC)rC)my Levron <jeremylevron@19h47.fr> (http://19h47.fr)",
     "license": "ISC",
     "bugs": {
         "url": "https://github.com/19h47/vacancespourseniors/issues"


### PR DESCRIPTION

Hello 19h47!

It seems like you have npm as one of your (dev-) dependency in vacances-pour-seniors.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
